### PR TITLE
Make the checkboxes clickable in dev processes so we can use the checklist for real

### DIFF
--- a/_includes/clickable-checkboxes.html
+++ b/_includes/clickable-checkboxes.html
@@ -1,1 +1,1 @@
-<script src="/assets/clickable-checkboxes.js"><\/script>
+<script src="/algorea-devdoc/assets/clickable-checkboxes.js"></script>

--- a/_includes/clickable-checkboxes.html
+++ b/_includes/clickable-checkboxes.html
@@ -1,0 +1,1 @@
+<script src="/assets/clickable-checkboxes.js"><\/script>

--- a/assets/clickable-checkboxes.js
+++ b/assets/clickable-checkboxes.js
@@ -1,6 +1,6 @@
-// Clickable checkboxes
-const checkboxes = document.querySelectorAll('input[type="checkbox"]');
-checkboxes.forEach(checkbox => {
-// remove the disabled attribute; added by kramdown by default
-checkbox.removeAttribute('disabled');
+document.addEventListener('DOMContentLoaded', function() {
+  const checkboxes = document.querySelectorAll('input[type="checkbox"]');
+  checkboxes.forEach(checkbox => {
+    checkbox.removeAttribute('disabled');
+  });
 });

--- a/assets/clickable-checkboxes.js
+++ b/assets/clickable-checkboxes.js
@@ -1,0 +1,6 @@
+// Clickable checkboxes
+const checkboxes = document.querySelectorAll('input[type="checkbox"]');
+checkboxes.forEach(checkbox => {
+// remove the disabled attribute; added by kramdown by default
+checkbox.removeAttribute('disabled');
+});

--- a/backend/dev-process.md
+++ b/backend/dev-process.md
@@ -5,6 +5,8 @@ nav_order: 10
 parent: Backend
 ---
 
+{% include clickable-checkboxes.html %}
+
 # Development Processes
 
 ## Checklist for a new PR


### PR DESCRIPTION
Checkboxes are disabled by default in the generated pages.

We can now enable them by including the right file.

This allows to use the checklists on the page while completing the tasks.