### PR TITLE
backend/ide_config.md: Windows and recommendations + "Cucumber Go" plugin

### DIFF
--- a/backend/ide_config.md
+++ b/backend/ide_config.md
@@ -7,30 +7,47 @@ parent: Backend
 
 # IDE Configuration and Processes
 
-We recommend Jetbrains GoLand or IntelliJ IDEA with Go plugin for the development of the backend.
-It eases the writing of the tests, the debugging, formatting, linting, and the integration with Git.
+The possible integrated development environments for the backend can be Jetbrains GoLand, or Microsoft Visual Studio Code, or IntelliJ IDEA with Go plugin, or whatever.
 
-We also recommend using GitHub Copilot (as of April 2024) for writing the code, as it'll make you gain a lot of time.
+Optionally, GitHub Copilot can be used to speed up code writing.
 
 
-## Jetbrains GoLand or IntelliJ IDEA with Go plugin
+## IntelliJ IDEA with Go plugin
 
 If you're using IntelliJ IDEA, you need to install the Go plugin. Go to `File` > `Settings` > `Plugins` and search for `Go`. Install it and restart the IDE.
 
 
+## Jetbrains Goland / IntelliJ IDEA
+
 ### Plugins
 
 Go to `File` > `Settings` > `Plugins` and install the following plugins:
+- `Cucumber Go` (https://plugins.jetbrains.com/plugin/24323-cucumber-go) for code completion in `*.feature` files and easy jumping to step definitions.
 - `Cucumber+`, helps to edit the `*.feature` files, especially the tables.
 - `Gherkin`, for the syntax of `*.feature` files.
 - `Makefile language support`, for the syntax of the `Makefile` file.
 - `Go linter`, to get the lint warnings in the IDE while editing files.
 - `File Watchers`, to automatically format the code on save.
 
+### Automatic code formatting on file save
 
-### For Windows: Add `diff` executable in the PATH
+Go to `File` > `Settings` > `Tools` > `File Watchers` and add a new watcher (if it is not there yet) with the following settings:
+- Name: `gofumpt`
+- File type: `Go`
+- Scope: `Project Files`
+- Program: `go`
 
-If you use Windows, you need to add the `diff` executable in the PATH.
+Note: `gofumpt` is a tool that formats Go code. It is stricter than `gofmt`.
+This will make sure the code and the imports are formatted correctly to pass the lint checks,
+when you save a file.
+
+## Developing on Windows
+
+It is generally NOT recommended to develop on Windows as the backend does not support running on Windows. But you still can try to do it if you have constraints that require using Windows (do not have your own computer, for instance).
+
+### IntelliJ IDEA: Add `git` executable in the PATH
+
+If you use Windows, you need to add the `git` executable in the PATH.
 
 The easiest way to do this is to:
 
@@ -56,16 +73,3 @@ Select the `Path` variable in the `User variables` or in `System variables` sect
 Click on "New", then type the path (default is C:\Program Files\Git\usr\bin), then click on "OK":
 
 ![Click on "New", then type the path (default is C:\Program Files\Git\usr\bin), then click on "OK"]({{ site.url }}{{ site.baseurl }}/assets/intellij-idea-windows-step4.png)
-
-
-### Automatic code formatting on file save
-
-Go to `File` > `Settings` > `Tools` > `File Watchers` and add a new watcher (if it is not there yet) with the following settings:
-- Name: `gofumpt`
-- File type: `Go`
-- Scope: `Project Files`
-- Program: `go`
-
-Note: `gofumpt` is a tool that formats Go code. It is stricter than `gofmt`.
-This will make sure the code and the imports are formatted correctly to pass the lint checks,
-when you save a file.


### PR DESCRIPTION
rework backend/ide_config.md:
1. Move Windows-related stuff to the bottom,
2. Remove the "recommend" word everywhere,
3. Mention the "Cucumber Go" plugin,
4. Note that development on Windows is NOT recommended.

Fixes #59 