### PR TITLE
Improve group visibility rules

### DIFF
--- a/groups/groups.md
+++ b/groups/groups.md
@@ -73,11 +73,11 @@ Must be descendant of a school. <span class="label label-yellow">Draft</span>
 
 A group `G` is visible to a user `U` if:
 
-1) `G` is an ancestor of `U` or
+1) `G` is an ancestor of `U` or `G` is an ancestor of at least one team `U` is member of or
 
 2) `G` is an ancestor of a non-user group `G'` that `U` manages explicitly or implicitly or
 
-3) `G` is a user who is implicitly managed by `U` or
+3) `G` is a user implicitly managed by `U` or is a member of a team managed by `U` (explicitly or implicitly) or
 
 4) `G` is public (`is_public` is true).
 

--- a/groups/groups.md
+++ b/groups/groups.md
@@ -73,13 +73,13 @@ Must be descendant of a school. <span class="label label-yellow">Draft</span>
 
 A group `G` is visible to a user `U` if:
 
-1) either `G` is an ancestor of `U`
+1) `G` is an ancestor of `U` or
 
-2) either `G` is an ancestor of a non-user group `G'` that `U` manages explicitely or implicitely
+2) `G` is an ancestor of a non-user group `G'` that `U` manages explicitly or implicitly or
 
-3) either `G` is a user who is implicitely managed by `U`.
+3) `G` is a user who is implicitly managed by `U` or
 
-4) either `G` is public (`is_public` is true)
+4) `G` is public (`is_public` is true).
 
 ### Explanations
 

--- a/groups/groups.md
+++ b/groups/groups.md
@@ -83,10 +83,10 @@ A group `G` is visible to a user `U` if:
 
 ### Explanations
 
-1) A user can see all the groups he is member of as well as their ancestors (he is implicitely member of them)
+1) A user can see all the groups he is member of as well as their ancestors (he is implicitly member of them)
 
-2) When a user is manager of a group, we consider he may know about all groups which are ancestors of the group he manages directly (explicitely) or any of its descendants (implicitely). Of course, that excludes ancestors of users he manages as he cannot be member of a user. Note that in theory, that should only apply the manager with `membership` level (as they may add themselves to these descendant groups anyway), but we extends it to all managers for simplicity.
+2) When a user is manager of a group, we consider he may know about all groups which are ancestors of the group he manages directly (explicitly) or any of its descendants (implicitly). Of course, that excludes ancestors of users he manages as he cannot be member of a user. Note that in theory, that should only apply the manager with `membership` level (as they may add themselves to these descendant groups anyway), but we extend it to all managers for simplicity.
 
-3) The manager (implicit or explicit) of a group should be able to see the users who are members of that group. In theory, that should only apply the manager with `level >= membership` or `can_watch_members=true` or `can_grant_group_access=true` but we extends it to all managers for simplicity. Anyway, managers without that permissions should be restricted on the service call directly, not at the row level.
+3) The manager (implicit or explicit) of a group should be able to see the users who are members of that group. In theory, that should only apply the manager with `level >= membership` or `can_watch_members=true` or `can_grant_group_access=true` but we extend it to all managers for simplicity. Anyway, managers without that permissions should be restricted on the service call directly, not at the row level.
 
 4) Public groups are by definition visible to everyone.

--- a/groups/groups.md
+++ b/groups/groups.md
@@ -75,9 +75,9 @@ A group `G` is visible to a user `U` if:
 
 1) `G` is an ancestor of `U` or `G` is an ancestor of at least one team `U` is member of or
 
-2) `G` is an ancestor of a non-user group `G'` that `U` manages explicitly or implicitly or
+2) `G` is an ancestor of a non-user group `G'` that `U` manages explicitly or implicitly with `can_manage>="memberships" or
 
-3) `G` is a user implicitly managed by `U` or is a member of a team managed by `U` (explicitly or implicitly) or
+3) `G` is a user implicitly managed by `U` or `G` is a member of a team managed by `U` (explicitly or implicitly) with `can_manage`>="membership" or `can_watch_members`=true or `can_grant_group_access`=true or
 
 4) `G` is public (`is_public` is true).
 
@@ -85,8 +85,8 @@ A group `G` is visible to a user `U` if:
 
 1) A user can see all the groups he is member of as well as their ancestors (he is implicitly member of them)
 
-2) When a user is manager of a group, we consider he may know about all groups which are ancestors of the group he manages directly (explicitly) or any of its descendants (implicitly). Of course, that excludes ancestors of users he manages as he cannot be member of a user. Note that in theory, that should only apply the manager with `membership` level (as they may add themselves to these descendant groups anyway), but we extend it to all managers for simplicity.
+2) When a user is manager of a group, we consider he may know about all groups which are ancestors of the group he manages directly (explicitly) or any of its descendants (implicitly) with `can_manage`>="membership" (as they may add themselves to these descendant groups anyway). Of course, that excludes ancestors of users he manages as he cannot be member of a user.
 
-3) The manager (implicit or explicit) of a group should be able to see the users who are members of that group. In theory, that should only apply the manager with `level >= membership` or `can_watch_members=true` or `can_grant_group_access=true` but we extend it to all managers for simplicity. Anyway, managers without that permissions should be restricted on the service call directly, not at the row level.
+3) The manager (implicit or explicit) of a group having `can_manage`>="membership" or `can_watch_members`=true or `can_grant_group_access`=true should be able to see the users who are members of that group.
 
 4) Public groups are by definition visible to everyone.

--- a/groups/groups.md
+++ b/groups/groups.md
@@ -75,7 +75,7 @@ A group `G` is visible to a user `U` if:
 
 1) `G` is an ancestor of `U` or `G` is an ancestor of at least one team `U` is member of or
 
-2) `G` is an ancestor of a non-user group `G'` that `U` manages explicitly or implicitly with `can_manage>="memberships" or
+2) `G` is an ancestor of a non-user group `G'` that `U` manages with `can_manage>="memberships" (explicitly or implicitly) or
 
 3) `G` is a user implicitly managed by `U` or `G` is a member of a team managed by `U` (explicitly or implicitly) with `can_manage`>="membership" or `can_watch_members`=true or `can_grant_group_access`=true or
 

--- a/groups/groups.md
+++ b/groups/groups.md
@@ -75,7 +75,7 @@ A group `G` is visible to a user `U` if:
 
 1) `G` is an ancestor of `U` or `G` is an ancestor of at least one team `U` is member of or
 
-2) `G` is an ancestor of a non-user group `G'` that `U` manages with `can_manage>="memberships" (explicitly or implicitly) or
+2) `G` is an ancestor of a non-user group `G'` that `U` manages with `can_manage`>="memberships" or `can_watch_members`=true or `can_grant_group_access`=true (explicitly or implicitly) or
 
 3) `G` is a user implicitly managed by `U` or `G` is a member of a team managed by `U` (explicitly or implicitly) with `can_manage`>="membership" or `can_watch_members`=true or `can_grant_group_access`=true or
 
@@ -83,10 +83,16 @@ A group `G` is visible to a user `U` if:
 
 ### Explanations
 
-1) A user can see all the groups he is member of as well as their ancestors (he is implicitly member of them)
+1) A user can see all the groups he is a member of as well as their ancestors (he is implicitly a member of them).
 
-2) When a user is manager of a group, we consider he may know about all groups which are ancestors of the group he manages directly (explicitly) or any of its descendants (implicitly) with `can_manage`>="membership" (as they may add themselves to these descendant groups anyway). Of course, that excludes ancestors of users he manages as he cannot be member of a user.
+2) When a user is a manager of a group (with `can_manage`>="memberships" or `can_watch_members`=true or `can_grant_group_access`=true), we consider they may know about all groups that are ancestors of the group he manages directly (explicitly) or via descendants (implicitly). Why we do this:
+  * When a user manages a group with `can_manage`>="memberships", he can himself into that group or any of its descendant (leading to the rule 1). This excludes ancestors of users the user manages as it's impossible to become a member of a user.
+  * When a user manages a group with `can_watch_members`=true, we allow him to see ancestors of the group for a REASON TO BE DOCUMENTED. This excludes ancestors of users the user manages as it's impossible for a user to have members.
+  * When a user manages a group with `can_grant_group_access`=true, we want the user to be able to all the permissions given to the group via any of its ancestors, so all the ancestors of the managed group should be visible to the user. This excludes ancestors of users for a REASON TO BE DOCUMENTED.
 
-3) The manager (implicit or explicit) of a group having `can_manage`>="membership" or `can_watch_members`=true or `can_grant_group_access`=true should be able to see the users who are members of that group.
+3) A manager (implicit or explicit) of a group having `can_manage`>="membership" or `can_watch_members`=true or `can_grant_group_access`=true should be able to see the users who are members of that group. Why we do this:
+  * When a user manages a group with `can_manage`>="membership", we allow them to see the members of that group for a REASON TO BE DOCUMENTED.
+  * When a user manages a group with `can_watch_members`=true, he should be able to see the members of that group because that's the purpose of that permission.
+  * When a user manages a group with `can_grant_group_access`=true, we want the user to be able to see all the members of that group for a REASON TO BE DOCUMENTED.
 
 4) Public groups are by definition visible to everyone.


### PR DESCRIPTION
1. Allow team members to see ancestors of their teams, include members of teams managed by the user
2. Remove unnecessary simplifications
3. Fix grammar and spelling